### PR TITLE
FOLS3CL-3: Upgrade aws-sdk-java, minio, netty, jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <java.version>11</java.version>
     <lombok.version>1.18.24</lombok.version>
     <apache.common.version>3.12.0</apache.common.version>
-    <minio.version>8.4.5</minio.version>
+    <minio.version>8.4.6</minio.version>
     <log4j.version>2.19.0</log4j.version>
-    <aws.sdk.version>2.17.267</aws.sdk.version>
+    <aws.sdk.version>2.19.2</aws.sdk.version>
     <junit.version>5.9.0</junit.version>
     <s3mock_2.13.version>0.2.6</s3mock_2.13.version>
     <testcontainers.version>1.17.6</testcontainers.version>

--- a/src/main/java/org/folio/s3/client/AwsS3Client.java
+++ b/src/main/java/org/folio/s3/client/AwsS3Client.java
@@ -60,6 +60,7 @@ public class AwsS3Client extends MinioS3Client {
 
     client = S3Client.builder()
       .endpointOverride(URI.create(endpoint))
+      .forcePathStyle(s3ClientProperties.isForcePathStyle())
       .region(Region.of(region))
       .credentialsProvider(credentialsProvider)
       .build();

--- a/src/main/java/org/folio/s3/client/MinioS3Client.java
+++ b/src/main/java/org/folio/s3/client/MinioS3Client.java
@@ -179,7 +179,7 @@ public class MinioS3Client implements FolioS3Client {
     try (is) {
       return write(path, is, new HashMap<>());
     } catch (Exception e) {
-      throw new S3ClientException("Error writing");
+      throw new S3ClientException("Error writing", e);
     }
   }
 

--- a/src/main/java/org/folio/s3/client/S3ClientProperties.java
+++ b/src/main/java/org/folio/s3/client/S3ClientProperties.java
@@ -31,8 +31,14 @@ public class S3ClientProperties {
    *  The credentials for access to object storage - secretKey.
    */
   private String secretKey;
+
   /**
    * Key that enables files merging in storage with using AWS SDK capabilities.
    */
   private boolean awsSdk;
+
+  /**
+   * True for bucket name in the path, false for bucket name in the virtual host name.
+   */
+  private boolean forcePathStyle;
 }

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -199,6 +199,7 @@ class FolioS3ClientTest {
   public static S3ClientProperties getS3ClientProperties(boolean isAwsSdk, String endpoint) {
     return S3ClientProperties.builder()
             .endpoint(endpoint)
+            .forcePathStyle(true)
             .secretKey(S3_SECRET_KEY)
             .accessKey(S3_ACCESS_KEY)
             .bucket(S3_BUCKET)


### PR DESCRIPTION
Upgrade aws-sdk-java from 2.17.267 to 2.19.1. This indirectly upgrades Netty from 4.1.77.Final to 4.1.86.Final fixing HTTP Response Splitting: https://nvd.nist.gov/vuln/detail/CVE-2022-41915

Upgrade minio from 8.4.5 to 8.4.6. This indirectly upgrades jackson-databind from 2.13.2.2 to 2.13.4.2 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2022-42003 , https://nvd.nist.gov/vuln/detail/CVE-2022-42004

aws-sdk-java since version 2.18.0 by default uses virtual-hosted-style S3 requests. We add the forcePathStyle option to S3ClientProperties because the folio-s3-client unit tests require path-style S3 requests.