### PR TITLE
FOLS3CL-11: Add method to get presigned URLs for PUT requests

### DIFF
--- a/src/main/java/org/folio/s3/client/FolioS3Client.java
+++ b/src/main/java/org/folio/s3/client/FolioS3Client.java
@@ -1,5 +1,6 @@
 package org.folio.s3.client;
 
+import io.minio.http.Method;
 import java.io.InputStream;
 import java.util.List;
 
@@ -82,11 +83,19 @@ public interface FolioS3Client {
   RemoteStorageWriter getRemoteStorageWriter(String path, int size);
 
   /**
-   * Returns presigned url for object on S3-compatible storage
+   * Returns presigned GET url for object on S3-compatible storage
    * @param path - the path to the file on S3-compatible storage
    * @return presigned url of object
    */
   String getPresignedUrl(String path);
+
+  /**
+   * Returns presigned url for object on S3-compatible storage
+   * @param path - the path to the file on S3-compatible storage
+   * @param method - http method
+   * @return presigned url of object
+   */
+  String getPresignedUrl(String path, Method method);
 
   /**
    * Creates bucket. Bucket name should be declared in {@link S3ClientProperties}

--- a/src/main/java/org/folio/s3/client/MinioS3Client.java
+++ b/src/main/java/org/folio/s3/client/MinioS3Client.java
@@ -314,11 +314,16 @@ public class MinioS3Client implements FolioS3Client {
 
   @Override
   public String getPresignedUrl(String path) {
+    return getPresignedUrl(path, Method.GET);
+  }
+
+  @Override
+  public String getPresignedUrl(String path, Method method) {
     try {
       return client.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
         .bucket(bucket)
         .object(path)
-        .method(Method.GET)
+        .method(method)
         .expiry(EXPIRATION_TIME_IN_MINUTES, TimeUnit.MINUTES)
         .build());
     } catch (Exception e) {

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Multimap;
 import io.minio.AbortMultipartUploadResponse;
 import io.minio.ObjectWriteResponse;
 import io.minio.PutObjectArgs;
+import io.minio.http.Method;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -148,6 +149,10 @@ class FolioS3ClientTest {
     Files.deleteIfExists(tempFilePath);
     Files.createFile(tempFilePath);
     Files.write(tempFilePath, content);
+
+    var link = s3Client.getPresignedUrl(fileOnStorage, Method.PUT);
+    assertNotNull(link);
+    assertTrue(link.contains(fileOnStorage));
 
     // Upload files content
     s3Client.upload(tempFilePath.toString(), fileOnStorage);


### PR DESCRIPTION
# [Jira](https://issues.folio.org/browse/FOLS3CL-11)

## Purpose
The improvements in [UXPROD-4337](https://issues.folio.org/browse/UXPROD-4337) require uploading files to S3 from the UI; for this, we will need a presigned PUT endpoint.

## Approach
To accomplish this, I made the `getPresignedUrl` method more generic, allowing it to accept any desired HTTP method.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
