### PR TITLE
FOLS3CL-13: Create suite of multipart API methods

### DIFF
--- a/src/main/java/org/folio/s3/client/FolioS3Client.java
+++ b/src/main/java/org/folio/s3/client/FolioS3Client.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.util.List;
 
 public interface FolioS3Client {
-
   /**
    * Upload file on S3-compatible storage
    *
@@ -16,8 +15,9 @@ public interface FolioS3Client {
   String upload(String path, String filename);
 
   /**
-   * Appends content of input stream to the file on S3 storage. In case file doesn't exist it will be created automatically.
-   * 
+   * Appends content of input stream to the file on S3 storage. In case file
+   * doesn't exist it will be created automatically.
+   *
    * @param path the path to the file on S3-compatible storage
    * @param is   input stream with appendable data
    * @return path of updated file
@@ -43,14 +43,15 @@ public interface FolioS3Client {
 
   /**
    * Removes a files on S3 storage
-   * 
+   *
    * @param paths array of file paths to delete
    * @return list of deleted file paths
    */
   List<String> remove(String... paths);
 
   /**
-   * Opens a file on remote storage, returns an input stream to read from the file. InputStream should be read and closed properly.
+   * Opens a file on remote storage, returns an input stream to read from the
+   * file. InputStream should be read and closed properly.
    *
    * @param path - the path to the file on S3-compatible storage
    * @return a new input stream with file content
@@ -84,6 +85,7 @@ public interface FolioS3Client {
 
   /**
    * Returns presigned GET url for object on S3-compatible storage
+   *
    * @param path - the path to the file on S3-compatible storage
    * @return presigned url of object
    */
@@ -91,7 +93,8 @@ public interface FolioS3Client {
 
   /**
    * Returns presigned url for object on S3-compatible storage
-   * @param path - the path to the file on S3-compatible storage
+   *
+   * @param path   - the path to the file on S3-compatible storage
    * @param method - http method
    * @return presigned url of object
    */
@@ -101,4 +104,72 @@ public interface FolioS3Client {
    * Creates bucket. Bucket name should be declared in {@link S3ClientProperties}
    */
   void createBucketIfNotExists();
+
+  /**
+   * Initiates a multipart upload, returning the upload ID.
+   *
+   * @param path - the path to the file on S3-compatible storage
+   * @return the multipart upload ID
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+   */
+  String initiateMultipartUpload(String path);
+
+  /**
+   * Gets a presigned URL to PUT a part of a multipart upload
+   *
+   * @param path       - the path to the file on S3-compatible storage
+   * @param uploadId   - the upload ID from
+   *                   {@link #initiateMultipartUpload(String)}
+   * @param partNumber - the part number of the part to upload, starts at 1
+   * @return the presigned URL
+   * @see {@link #initiateMultipartUpload(String)}
+   */
+  String createPresignedMultipartUploadUrl(
+      String path,
+      String uploadId,
+      int partNumber);
+
+  /**
+   * Uploads a part of a multipart upload from a local file
+   *
+   * @param path       - the path to the file on S3-compatible storage
+   * @param uploadId   - the upload ID from
+   *                   {@link #initiateMultipartUpload(String)}
+   * @param partNumber - the part number of the part to upload, starts at 1
+   * @param filename   - the local uploaded file on disk
+   * @return the upload's eTag
+   * @see {@link #initiateMultipartUpload(String)}
+   */
+  String uploadMultipartPart(
+      String path,
+      String uploadId,
+      int partNumber,
+      String filename);
+
+  /**
+   * Aborts a multipart upload. Note: **this may need to be done multiple times**
+   *
+   * @param path     - the path to the file on S3-compatible storage
+   * @param uploadId - the upload ID from {@link #initiateMultipartUpload(String)}
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+   * @see {@link #initiateMultipartUpload(String)}
+   */
+  void abortMultipartUpload(String path, String uploadId);
+
+  /**
+   * Completes a multipart upload. Note: **this may take several minutes to
+   * complete**
+   *
+   * @param path      - the path to the file on S3-compatible storage
+   * @param uploadId  - the upload ID from
+   *                  {@link #initiateMultipartUpload(String)}
+   * @param partETags - the list of uploaded parts' eTags
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+   * @see {@link #initiateMultipartUpload(String)}
+   * @see {@link #createPresignedMultipartUploadUrl(String, String, int)}
+   */
+  void completeMultipartUpload(
+      String path,
+      String uploadId,
+      List<String> partETags);
 }

--- a/src/main/java/org/folio/s3/client/FolioS3Client.java
+++ b/src/main/java/org/folio/s3/client/FolioS3Client.java
@@ -124,7 +124,7 @@ public interface FolioS3Client {
    * @return the presigned URL
    * @see {@link #initiateMultipartUpload(String)}
    */
-  String createPresignedMultipartUploadUrl(
+  String getPresignedMultipartUploadUrl(
       String path,
       String uploadId,
       int partNumber);

--- a/src/main/java/org/folio/s3/client/MinioS3Client.java
+++ b/src/main/java/org/folio/s3/client/MinioS3Client.java
@@ -348,7 +348,7 @@ public class MinioS3Client implements FolioS3Client {
   }
 
   @Override
-  public String createPresignedMultipartUploadUrl(
+  public String getPresignedMultipartUploadUrl(
     String path,
     String uploadId,
     int partNumber

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -465,12 +465,11 @@ class FolioS3ClientTest {
         S3ClientException.class,
         () -> s3Client.completeMultipartUpload(fileOnStorage, uploadId, new ArrayList<>()));
 
-    // the presigned URL will always generate successfully, only failing later upon
-    // upload
-    // we'll give a bad part number to simulate failure
+    // the presigned URL will always generate successfully, only failing later on upload
+    // we'll give a bad parameters to simulate failure
     assertThrows(
         S3ClientException.class,
-        () -> s3Client.getPresignedMultipartUploadUrl(fileOnStorage, uploadId, -1));
+        () -> s3Client.getPresignedMultipartUploadUrl(null, null, 1));
 
     // and to check that a bad filename results in failure
     assertThrows(

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -74,12 +74,12 @@ class FolioS3ClientTest {
   @BeforeAll
   public static void setUp() {
     s3 = new GenericContainer<>("minio/minio:latest").withEnv("MINIO_ACCESS_KEY", S3_ACCESS_KEY)
-        .withEnv("MINIO_SECRET_KEY", S3_SECRET_KEY)
-        .withCommand("server /data")
-        .withExposedPorts(S3_PORT)
-        .waitingFor(new HttpWaitStrategy().forPath("/minio/health/ready")
-            .forPort(S3_PORT)
-            .withStartupTimeout(Duration.ofSeconds(10)));
+      .withEnv("MINIO_SECRET_KEY", S3_SECRET_KEY)
+      .withCommand("server /data")
+      .withExposedPorts(S3_PORT)
+      .waitingFor(new HttpWaitStrategy().forPath("/minio/health/ready")
+        .forPort(S3_PORT)
+        .withStartupTimeout(Duration.ofSeconds(10)));
     s3.start();
 
     endpoint = format("http://%s:%s", s3.getHost(), s3.getFirstMappedPort());

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -397,7 +397,7 @@ class FolioS3ClientTest {
       );
       assertNotNull(eTag);
       return eTag;
-    }).toList();
+    }).collect(toList());
 
     // complete upload
     s3Client.completeMultipartUpload(fileOnStorage, uploadId, eTags);

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -10,14 +10,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -340,6 +345,147 @@ class FolioS3ClientTest {
     final FolioS3Client client = S3ClientFactory.getS3Client(getS3ClientProperties(false, endpoint));
 
     assertThrows(S3ClientException.class, () -> client.getRemoteStorageWriter(path, size));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void testMultipart(boolean isAwsSdk) throws IOException {
+    S3ClientProperties properties = getS3ClientProperties(isAwsSdk, endpoint);
+    FolioS3Client s3Client = S3ClientFactory.getS3Client(properties);
+    s3Client.createBucketIfNotExists();
+
+    var fileOnStorage = "directory/file.ext";
+
+    List<byte[]> contents = Arrays.asList(
+      getRandomBytes(LARGE_SIZE),
+      getRandomBytes(LARGE_SIZE),
+      getRandomBytes(SMALL_SIZE)
+    );
+    List<Path> tempFilePaths = Arrays.asList(
+      Paths.get("part1"),
+      Paths.get("part2"),
+      Paths.get("part3")
+    );
+
+    IntStream.range(0, 3).forEach(i -> {
+      try {
+        Files.deleteIfExists(tempFilePaths.get(i));
+        Files.createFile(tempFilePaths.get(i));
+        Files.write(tempFilePaths.get(i), contents.get(i));
+      } catch(IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+
+    // start upload
+    String uploadId = s3Client.initiateMultipartUpload(fileOnStorage);
+    assertNotNull(uploadId);
+
+    List<String> eTags = IntStream.rangeClosed(1, 3).mapToObj(i -> {
+      // get presigned URLs
+      String link = s3Client.createPresignedMultipartUploadUrl(fileOnStorage, uploadId, i);
+      assertNotNull(link);
+      assertTrue(link.contains("partNumber=" + i));
+      assertTrue(link.contains(fileOnStorage));
+
+      // upload it (normal way)
+      String eTag = s3Client.uploadMultipartPart(
+        fileOnStorage,
+        uploadId,
+        i,
+        tempFilePaths.get(i - 1).toString()
+      );
+      assertNotNull(eTag);
+      return eTag;
+    }).toList();
+
+    // complete upload
+    s3Client.completeMultipartUpload(fileOnStorage, uploadId, eTags);
+
+    // too late to abort
+    assertThrows(S3ClientException.class, () -> s3Client.abortMultipartUpload(fileOnStorage, uploadId));
+
+    assertEquals(1, s3Client.list("directory/").size());
+    assertEquals("directory/file.ext", s3Client.list("directory/").get(0));
+
+    // Read files content
+    try (InputStream is = s3Client.read(fileOnStorage)) {
+      byte[] fromS3 = is.readAllBytes();
+      assertTrue(Objects.deepEquals(contents.get(0), Arrays.copyOfRange(fromS3, 0, LARGE_SIZE)));
+      assertTrue(Objects.deepEquals(contents.get(1), Arrays.copyOfRange(fromS3, LARGE_SIZE, LARGE_SIZE * 2)));
+      assertTrue(Objects.deepEquals(contents.get(2), Arrays.copyOfRange(fromS3, LARGE_SIZE * 2, LARGE_SIZE * 2 + SMALL_SIZE)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    // Remove files files
+    s3Client.remove(fileOnStorage);
+    assertEquals("[]", s3Client.list("directory/").toString());
+
+    tempFilePaths.forEach(path -> {
+      try {
+        Files.deleteIfExists(path);
+      } catch(IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void testMultipartExceptions(boolean isAwsSdk) throws IOException {
+    S3ClientProperties properties = getS3ClientProperties(isAwsSdk, endpoint);
+    FolioS3Client s3Client = S3ClientFactory.getS3Client(properties);
+    s3Client.createBucketIfNotExists();
+
+    var fileOnStorage = "directory/file.ext";
+
+    byte[] content = getRandomBytes(LARGE_SIZE);
+    Path tempFilePath = Paths.get("part1");
+
+    Files.deleteIfExists(tempFilePath);
+    Files.createFile(tempFilePath);
+    Files.write(tempFilePath, content);
+
+    // start upload
+    String uploadId = s3Client.initiateMultipartUpload(fileOnStorage);
+    assertNotNull(uploadId);
+
+    // abort upload
+    s3Client.abortMultipartUpload(fileOnStorage, uploadId);
+
+    // now, all further operations should fail...
+    assertThrows(
+      S3ClientException.class,
+      () -> s3Client.uploadMultipartPart(
+        fileOnStorage,
+        uploadId,
+        1,
+        tempFilePath.toString()
+      )
+    );
+    assertThrows(
+      S3ClientException.class,
+      () -> s3Client.completeMultipartUpload(fileOnStorage, uploadId, Arrays.asList())
+    );
+
+    // the presigned URL will always generate successfully, only failing later upon upload
+    // we'll give a bad part number to simulate failure
+    assertThrows(
+      S3ClientException.class,
+      () -> s3Client.completeMultipartUpload(fileOnStorage, uploadId, Arrays.asList())
+    );
+
+    // and to check that a bad filename results in failure
+    assertThrows(
+      S3ClientException.class,
+      () -> s3Client.initiateMultipartUpload("")
+    );
+
+    // nothing should have been saved
+    assertEquals("[]", s3Client.list("directory/").toString());
+
+    Files.deleteIfExists(tempFilePath);
   }
 
   // TODO: delete isAwsSdk in the future because of AWS S3 will be unsupported

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -105,8 +105,8 @@ class FolioS3ClientTest {
     List<String> expected;
     try {
       expected = original.stream()
-          .map(p -> s3Client.write(p, new ByteArrayInputStream(content)))
-          .collect(toList());
+        .map(p -> s3Client.write(p, new ByteArrayInputStream(content)))
+        .collect(toList());
     } catch (Exception e) {
       throw new IOException(e);
     }
@@ -114,8 +114,7 @@ class FolioS3ClientTest {
     assertTrue(Objects.deepEquals(original, expected));
 
     assertTrue(
-        Objects.deepEquals(s3Client.list("directory_1/"),
-            List.of("directory_1/CSV_Data_1.csv", "directory_1/directory_2/")));
+        Objects.deepEquals(s3Client.list("directory_1/"), List.of("directory_1/CSV_Data_1.csv", "directory_1/directory_2/")));
 
     assertTrue(Objects.deepEquals(s3Client.list("directory_1/directory_2/"),
         List.of("directory_1/directory_2/CSV_Data_2.csv", "directory_1/directory_2/directory_3/")));
@@ -132,12 +131,13 @@ class FolioS3ClientTest {
       }
     });
 
+
     // Remove files files
     String[] paths = new String[original.size()];
     original.toArray(paths);
     s3Client.remove(paths);
     assertEquals(0, s3Client.list("directory_1/")
-        .size());
+      .size());
   }
 
   @ParameterizedTest
@@ -164,9 +164,9 @@ class FolioS3ClientTest {
     s3Client.upload(tempFilePath.toString(), fileOnStorage);
 
     assertEquals(1, s3Client.list("directory_1/")
-        .size());
+      .size());
     assertEquals("directory_1/CSV_Data_1.csv", s3Client.list("directory_1/")
-        .get(0));
+      .get(0));
 
     // Read files content
     try (var is = s3Client.read(fileOnStorage)) {
@@ -178,7 +178,7 @@ class FolioS3ClientTest {
     // Remove files files
     s3Client.remove(fileOnStorage);
     assertEquals("[]", s3Client.list("directory_1/")
-        .toString());
+      .toString());
 
     Files.deleteIfExists(tempFilePath);
   }
@@ -219,7 +219,7 @@ class FolioS3ClientTest {
       @SneakyThrows
       public CompletableFuture<ObjectWriteResponse> putObject(PutObjectArgs args) {
         if (args.extraQueryParams()
-            .isEmpty()) {
+          .isEmpty()) {
           return super.putObject(args);
         }
         throw new NegativeArraySizeException("greetings from mock");
@@ -227,11 +227,9 @@ class FolioS3ClientTest {
 
       @SneakyThrows
       public CompletableFuture<AbortMultipartUploadResponse> abortMultipartUploadAsync(String bucketName, String region,
-          String objectName, String uploadId, Multimap<String, String> extraHeaders,
-          Multimap<String, String> extraQueryParams) {
+          String objectName, String uploadId, Multimap<String, String> extraHeaders, Multimap<String, String> extraQueryParams) {
         aborted.set(true);
-        return super.abortMultipartUploadAsync(bucketName, region, objectName, uploadId, extraHeaders,
-            extraQueryParams);
+        return super.abortMultipartUploadAsync(bucketName, region, objectName, uploadId, extraHeaders, extraQueryParams);
       }
     };
     var s3Client = new MinioS3Client(properties, mock);
@@ -240,7 +238,7 @@ class FolioS3ClientTest {
     var stream = new ByteArrayInputStream(content);
     var e = assertThrows(S3ClientException.class, () -> s3Client.append(path, stream));
     assertEquals("greetings from mock", e.getCause()
-        .getMessage());
+      .getMessage());
     assertTrue(aborted.get());
   }
 
@@ -285,7 +283,7 @@ class FolioS3ClientTest {
     var stream = new ByteArrayInputStream(content);
     var e = assertThrows(S3ClientException.class, () -> mockClient.append(path, stream));
     assertEquals("greetings from mock", e.getCause()
-        .getMessage());
+      .getMessage());
     assertTrue(aborted.get());
   }
 
@@ -302,8 +300,7 @@ class FolioS3ClientTest {
     assertThrows(S3ClientException.class, () -> s3Client.upload(fakeLocalPath, fakeLocalPath));
 
     // compose
-    // assertThrows(S3ClientException.class, () -> s3Client.append(fakeRemotePath,
-    // new ByteArrayInputStream(new byte[0])));
+//    assertThrows(S3ClientException.class, () -> s3Client.append(fakeRemotePath, new ByteArrayInputStream(new byte[0])));
 
     // write
     assertThrows(S3ClientException.class, () -> s3Client.write(fakeLocalPath, null));
@@ -311,18 +308,18 @@ class FolioS3ClientTest {
     // remove
     assertThrows(S3ClientException.class, () -> s3Client.remove(StringUtils.EMPTY));
     assertTrue(s3Client.remove(new String[0])
-        .isEmpty());
+      .isEmpty());
 
     // read
     assertThrows(S3ClientException.class, () -> s3Client.read(fakeRemotePath));
 
     // list
     assertTrue(s3Client.list(fakeRemotePath)
-        .isEmpty());
+      .isEmpty());
   }
 
   @ParameterizedTest
-  @ValueSource(ints = { SMALL_SIZE, LARGE_SIZE })
+  @ValueSource(ints = {SMALL_SIZE, LARGE_SIZE})
   void testRemoteStorageWriter(int size) throws IOException {
     final String path = "opt-writer/test.txt";
 
@@ -414,8 +411,7 @@ class FolioS3ClientTest {
       byte[] fromS3 = is.readAllBytes();
       assertTrue(Objects.deepEquals(contents.get(0), Arrays.copyOfRange(fromS3, 0, LARGE_SIZE)));
       assertTrue(Objects.deepEquals(contents.get(1), Arrays.copyOfRange(fromS3, LARGE_SIZE, LARGE_SIZE * 2)));
-      assertTrue(
-          Objects.deepEquals(contents.get(2), Arrays.copyOfRange(fromS3, LARGE_SIZE * 2, LARGE_SIZE * 2 + SMALL_SIZE)));
+      assertTrue(Objects.deepEquals(contents.get(2), Arrays.copyOfRange(fromS3, LARGE_SIZE * 2, LARGE_SIZE * 2 + SMALL_SIZE)));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -490,20 +486,20 @@ class FolioS3ClientTest {
   // TODO: delete isAwsSdk in the future because of AWS S3 will be unsupported
   public static S3ClientProperties getS3ClientProperties(boolean isAwsSdk, String endpoint) {
     return S3ClientProperties.builder()
-        .endpoint(endpoint)
-        .forcePathStyle(true)
-        .secretKey(S3_SECRET_KEY)
-        .accessKey(S3_ACCESS_KEY)
-        .bucket(S3_BUCKET)
-        .awsSdk(isAwsSdk)
-        .region(S3_REGION)
-        .build();
+      .endpoint(endpoint)
+      .forcePathStyle(true)
+      .secretKey(S3_SECRET_KEY)
+      .accessKey(S3_ACCESS_KEY)
+      .bucket(S3_BUCKET)
+      .awsSdk(isAwsSdk)
+      .region(S3_REGION)
+      .build();
   }
 
   public static byte[] getRandomBytes(int size) {
     var original = new byte[size];
     ThreadLocalRandom.current()
-        .nextBytes(original);
+      .nextBytes(original);
     return original;
   }
 }

--- a/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientTest.java
@@ -461,9 +461,11 @@ class FolioS3ClientTest {
             uploadId,
             1,
             tempFilePathString));
+
+    List<String> emptyList = new ArrayList<>();
     assertThrows(
         S3ClientException.class,
-        () -> s3Client.completeMultipartUpload(fileOnStorage, uploadId, new ArrayList<>()));
+        () -> s3Client.completeMultipartUpload(fileOnStorage, uploadId, emptyList));
 
     // the presigned URL will always generate successfully, only failing later on upload
     // we'll give a bad parameters to simulate failure


### PR DESCRIPTION
# [Jira](https://issues.folio.org/browse/FOLS3CL-13)

## Purpose
This adds a set of multipart upload methods:
- `String initiateMultipartUpload(String path);`
  - Create a multipart upload session
- `String createPresignedMultipartUploadUrl(String path, String uploadId, int partNumber);`
  - Create a presigned URL for a multipart part upload
- `String uploadMultipartPart(String path, String uploadId, int partNumber, String filename);`
  - Upload a multipart part (based on existing `upload`)
- `void abortMultipartUpload(String path, String uploadId);`
  - Abort a multipart upload session
- `void completeMultipartUpload(String path, String uploadId, List<String> partETags);`
  - Complete a multipart upload session, calling S3 to reconcile and combine all uploaded parts.

## Approach
This adds S3 methods similar to the existing ones to support this new functionality

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
