### PR TITLE
FOLS3CL-20: Java 17, upgrade dependencies for Poppy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildMvn {
   publishModDescriptor = 'no'
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,16 +16,14 @@
   </licenses>
 
   <properties>
-    <java.version>11</java.version>
-    <lombok.version>1.18.24</lombok.version>
-    <apache.common.version>3.12.0</apache.common.version>
-    <minio.version>8.5.2</minio.version>
-    <log4j.version>2.19.0</log4j.version>
-    <aws.sdk.version>2.19.2</aws.sdk.version>
-    <junit.version>5.9.0</junit.version>
-    <s3mock_2.13.version>0.2.6</s3mock_2.13.version>
+    <lombok.version>1.18.30</lombok.version>
+    <apache.commons.lang3.version>3.13.0</apache.commons.lang3.version>
+    <minio.version>8.5.6</minio.version>
+    <log4j.version>2.20.0</log4j.version>
+    <aws.sdk.version>2.21.14</aws.sdk.version>
+    <junit.version>5.10.0</junit.version>
     <testcontainers.version>1.17.6</testcontainers.version>
-    <commons-io.version>2.6</commons-io.version>
+    <commons-io.version>2.15.0</commons-io.version>
     <sonar.exclusions>
       **/src/main/java/org/folio/s3/client/S3ClientProperties.java
     </sonar.exclusions>
@@ -46,7 +44,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${apache.common.version}</version>
+      <version>${apache.commons.lang3.version}</version>
     </dependency>
     <dependency>
       <groupId>io.minio</groupId>
@@ -79,7 +77,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.17.6</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -90,7 +88,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>2.16.1</version>
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
@@ -99,7 +97,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -120,7 +118,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -138,7 +136,7 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -152,7 +150,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -166,7 +164,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>deploy</id>
@@ -177,20 +175,20 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.11.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <release>17</release>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>3.0.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -202,7 +200,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>3.2.1</version>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
https://issues.folio.org/browse/FOLS3CL-20

For Poppy FOLIO no longer supports Java 11 and requires all software libraries to upgrade to Java 17.

Upgrade all dependencies, this fixes these security vulnerabilities:

* netty-codec-http2 Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2023-44487
* snappy-java Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2023-34455
* snappy-java Integer Overflow or Wraparound https://nvd.nist.gov/vuln/detail/CVE-2023-34454
* snappy-java Integer Overflow or Wraparound https://nvd.nist.gov/vuln/detail/CVE-2023-34453
* snappy-java Allocation of Resources Without Limits or Throttling https://nvd.nist.gov/vuln/detail/CVE-2023-43642
* commons-io Directory Traversal https://nvd.nist.gov/vuln/detail/CVE-2021-29425
* okio-jvm Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2023-3635
* netty-handler Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2023-34462
* bcprov-jdk15on Information Exposure https://nvd.nist.gov/vuln/detail/CVE-2023-33201
* commons-codec Information Exposure https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518
* guava Creation of Temporary File in Directory with Insecure Permissions https://nvd.nist.gov/vuln/detail/CVE-2023-2976