### PR TITLE
FOLS3CL-21: Fix javadoc errors for Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
   </licenses>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <lombok.version>1.18.30</lombok.version>
     <apache.commons.lang3.version>3.13.0</apache.commons.lang3.version>
     <minio.version>8.5.6</minio.version>
@@ -154,7 +155,7 @@
         <executions>
           <execution>
             <id>attach-javadocs</id>
-            <phase>deploy</phase>
+            <phase>verify</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/src/main/java/org/folio/s3/client/FolioS3Client.java
+++ b/src/main/java/org/folio/s3/client/FolioS3Client.java
@@ -110,7 +110,8 @@ public interface FolioS3Client {
    *
    * @param path - the path to the file on S3-compatible storage
    * @return the multipart upload ID
-   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+   * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">
+   *     https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html</a>
    */
   String initiateMultipartUpload(String path);
 
@@ -122,7 +123,7 @@ public interface FolioS3Client {
    *                   {@link #initiateMultipartUpload(String)}
    * @param partNumber - the part number of the part to upload, starts at 1
    * @return the presigned URL
-   * @see {@link #initiateMultipartUpload(String)}
+   * @see #initiateMultipartUpload(String)
    */
   String getPresignedMultipartUploadUrl(
       String path,
@@ -138,7 +139,7 @@ public interface FolioS3Client {
    * @param partNumber - the part number of the part to upload, starts at 1
    * @param filename   - the local uploaded file on disk
    * @return the upload's eTag
-   * @see {@link #initiateMultipartUpload(String)}
+   * @see #initiateMultipartUpload(String)
    */
   String uploadMultipartPart(
       String path,
@@ -151,8 +152,9 @@ public interface FolioS3Client {
    *
    * @param path     - the path to the file on S3-compatible storage
    * @param uploadId - the upload ID from {@link #initiateMultipartUpload(String)}
-   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
-   * @see {@link #initiateMultipartUpload(String)}
+   * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">
+   *     https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html</a>
+   * @see #initiateMultipartUpload(String)
    */
   void abortMultipartUpload(String path, String uploadId);
 
@@ -164,9 +166,10 @@ public interface FolioS3Client {
    * @param uploadId  - the upload ID from
    *                  {@link #initiateMultipartUpload(String)}
    * @param partETags - the list of uploaded parts' eTags
-   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
-   * @see {@link #initiateMultipartUpload(String)}
-   * @see {@link #createPresignedMultipartUploadUrl(String, String, int)}
+   * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">
+   *   https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html</a>
+   * @see #initiateMultipartUpload(String)
+   * @see #getPresignedMultipartUploadUrl(String, String, int)
    */
   void completeMultipartUpload(
       String path,

--- a/src/main/java/org/folio/s3/client/S3ClientFactory.java
+++ b/src/main/java/org/folio/s3/client/S3ClientFactory.java
@@ -6,9 +6,9 @@ public class S3ClientFactory {
     }
 
     /**
-     * Returns {@link FolioS3Client} implementation based on value of {@link S3ClientProperties#isAwsSdk()} value
+     * Returns {@link FolioS3Client} implementation based on value of {@link S3ClientProperties}#isAwsSdk() value
      * @param s3ClientProperties - S3 client properties
-     * @return {@link AwsS3Client} if {@link S3ClientProperties#isAwsSdk()} is true, otherwise - {@link MinioS3Client}
+     * @return {@link AwsS3Client} if {@link S3ClientProperties}#isAwsSdk() is true, otherwise - {@link MinioS3Client}
      */
     public static FolioS3Client getS3Client(S3ClientProperties s3ClientProperties) {
         if (s3ClientProperties.isAwsSdk()) {


### PR DESCRIPTION
Java 17 is more picky about invalid javadoc:
https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html

Invalid javadoc fails the build in the deploy phase:
https://jenkins-aws.indexdata.com/blue/organizations/jenkins/folio-org%2Ffolio-s3-client/detail/master/15/pipeline

Tasks:
* Fix invalid javadoc
* Run maven-javadoc-plugin in the verify phase to fail the pull request on invalid javadoc