### PR TITLE
FOLS3CL-29: Upgrade dependencies for Quesnelia

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,13 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <lombok.version>1.18.30</lombok.version>
-    <apache.commons.lang3.version>3.13.0</apache.commons.lang3.version>
-    <minio.version>8.5.7</minio.version>
-    <log4j.version>2.20.0</log4j.version>
-    <aws.sdk.version>2.21.19</aws.sdk.version>
-    <junit.version>5.10.0</junit.version>
-    <testcontainers.version>1.17.6</testcontainers.version>
-    <commons-io.version>2.15.0</commons-io.version>
+    <apache.commons.lang3.version>3.14.0</apache.commons.lang3.version>
+    <minio.version>8.5.9</minio.version>
+    <log4j.version>2.23.1</log4j.version>
+    <aws.sdk.version>2.25.12</aws.sdk.version>
+    <junit.version>5.10.2</junit.version>
+    <testcontainers.version>1.19.7</testcontainers.version>
+    <commons-io.version>2.15.1</commons-io.version>
     <sonar.exclusions>
       **/src/main/java/org/folio/s3/client/S3ClientProperties.java
     </sonar.exclusions>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLS3CL-29

Upgrade all dependencies to a supported production version.

Upgrade minio from 8.5.7 to 8.5.9. This indirectly upgrades commons-compress from 1.24.0 to 1.26.0 fixing two vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2024-25710 - Infinite Loop
* https://nvd.nist.gov/vuln/detail/CVE-2024-26308 - Allocation of Resources Without Limits or Throttling

Upgrade commons-lang3 from 3.13.0 to 3.14.0.

Upgrade log4j from 2.20.0 to 2.23.1.

Upgrade aws.sdk s3 from 2.21.19 to 2.25.12.

Upgrade junit from 5.10.0 to 5.10.2.

Upgrade testcontainers from 1.17.6 to 1.19.7.

Upgrade commons-io 2.15.0 to 2.15.1.