### PR TITLE
FOLS3CL-33 - Add subPath functionality to folio S3 client

### DIFF
--- a/src/main/java/org/folio/s3/client/AwsS3Client.java
+++ b/src/main/java/org/folio/s3/client/AwsS3Client.java
@@ -76,7 +76,7 @@ public class AwsS3Client extends MinioS3Client {
     try (is) {
       return client.putObject(PutObjectRequest.builder()
                       .bucket(bucket)
-                      .key(path)
+                      .key(addSubPathIfPresent(path))
                       .build(), AsyncRequestBody.fromBytes(is.readAllBytes()))
               .thenApply(response -> path)
               .get();
@@ -92,7 +92,7 @@ public class AwsS3Client extends MinioS3Client {
       UploadRequest uploadRequest = UploadRequest.builder()
               .putObjectRequest(PutObjectRequest.builder()
                       .bucket(bucket)
-                      .key(path)
+                      .key(addSubPathIfPresent(path))
                       .build())
               .requestBody(AsyncRequestBody.fromInputStream(is, size, Executors.newCachedThreadPool()))
               .build();

--- a/src/main/java/org/folio/s3/client/S3ClientProperties.java
+++ b/src/main/java/org/folio/s3/client/S3ClientProperties.java
@@ -23,6 +23,11 @@ public class S3ClientProperties {
   private String bucket;
 
   /**
+   * The object storage subfolder.
+   */
+  private String subPath;
+
+  /**
    * The credentials for access to object storage - accessKey.
    */
   private String accessKey;


### PR DESCRIPTION
[FOLS3CL-33](https://folio-org.atlassian.net/browse/FOLS3CL-33) - Add subPath functionality to folio S3 client

## Purpose
More and more modules uses S3 integration for their needs.
With current folio-s3-client implementation it requires to create separate S3 bucket for each module. It’s ok when we talk about production set up and want to isolate buckets, but for dev environments it’s causes the issue with buckets managment and AWS limits.

So we propose to add possibility to specify subPath in backet that will allow to point all modules that uses S3 integration to single bucket with different folders.

## Approach
* Introduced subPath configuration value
* Improved clients logic
* Updated unit tests

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [ ] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
