### PR TITLE
FOLS3CL-37: Upgrade minio and aws sdk for Ramsons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <lombok.version>1.18.30</lombok.version>
     <apache.commons.lang3.version>3.14.0</apache.commons.lang3.version>
-    <minio.version>8.5.9</minio.version>
+    <minio.version>8.5.13</minio.version>
     <log4j.version>2.23.1</log4j.version>
-    <aws.sdk.version>2.25.12</aws.sdk.version>
+    <aws.sdk.version>2.29.6</aws.sdk.version>
     <junit.version>5.10.2</junit.version>
     <testcontainers.version>1.19.7</testcontainers.version>
     <commons-io.version>2.15.1</commons-io.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLS3CL-37

Upgrade minio from 8.5.9 to 8.5.13.

Upgrade aws sdk from 2.25.12 to 2.29.6.

These two upgrades fix these vulnerabilities in them:

* https://security.snyk.io/package/maven/org.bouncycastle:bcprov-jdk18on
* https://security.snyk.io/package/maven/io.netty:netty-codec-http
* https://security.snyk.io/package/maven/org.jetbrains.kotlin:kotlin-stdlib

## Purpose
Upgrade dependencies for Ramsons. Fixing vulnerabilities.

## Approach
Increment version in pom.xml.

## Learning
Before making the first release for a new flower release bump all dependencies.