### PR TITLE
Bump localstack image from 3.3.0 to s3-latest

### DIFF
--- a/src/test/java/org/folio/s3/client/FolioS3ClientFolderTest.java
+++ b/src/test/java/org/folio/s3/client/FolioS3ClientFolderTest.java
@@ -66,7 +66,7 @@ class FolioS3ClientSubPathTest {
   @BeforeAll
   public static void setUp() {
 
-    DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:3.3.0");
+    DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:s3-latest");
 
     localstack = new LocalStackContainer(localstackImage)
             .withStartupTimeout(Duration.of(1, MINUTES))


### PR DESCRIPTION
## Purpose
localstack 3.3.0 has been released March 2024 and is outdated.
It is very big.

## Approach
Switch from 3.3.0 to s3-latest that is current and much smaller.

localstack 3.3.0 image size: 415 MB - https://hub.docker.com/r/localstack/localstack/tags?name=3.3.0
localstack s3 image size: 109 MB - https://hub.docker.com/r/localstack/localstack/tags?name=s3

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.