### PR TITLE
FOLS3CL-48: awssdk:s3@2.40.17 fixing Netty CRLF CVE-2025-67735

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
       **/src/main/java/org/folio/s3/client/S3ClientProperties.java
     </sonar.exclusions>
   </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <minio.version>8.6.0</minio.version>
     <okhttp.version>5.1.0</okhttp.version>
     <log4j.version>2.23.1</log4j.version>
-    <aws.sdk.version>2.40.2</aws.sdk.version>
+    <aws.sdk.version>2.40.17</aws.sdk.version>
     <junit.version>5.12.0</junit.version>
     <testcontainers.version>1.20.5</testcontainers.version>
     <commons-io.version>2.18.0</commons-io.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLS3CL-48

## Purpose
Fix the security vulnerability CVE-2025-67735 = https://github.com/advisories/GHSA-84h7-rjj3-6jx4 = Netty CRLF Injection causing parser desynchronization, request smuggling, and response splitting

## Approach
Bump awssdk:s3 from 2.40.2 to 2.40.17.

This transitively bumps io.netty:netty-codec-http from 4.1.126.Final to 4.1.130.Final fixing the security vulnerability.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - n/a Were any API paths or methods changed, added or removed?
   - n/a Were there any schema changes?
   - n/a Did any of the interface versions change?
   - n/a Were permissions changed, added, or removed?
   - n/a Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.