### PR TITLE
FOLS3CL-51: Upgrade dependencies for Trillium, fix vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,19 +20,15 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <lombok.version>1.18.36</lombok.version>
-    <apache.commons.lang3.version>3.17.0</apache.commons.lang3.version>
+    <lombok.version>1.18.44</lombok.version>
+    <apache.commons.lang3.version>3.20.0</apache.commons.lang3.version>
     <minio.version>8.6.0</minio.version>
-    <okhttp.version>5.1.0</okhttp.version>
-    <log4j.version>2.23.1</log4j.version>
-    <aws.sdk.version>2.40.17</aws.sdk.version>
-    <junit.version>5.12.0</junit.version>
-    <testcontainers.version>1.20.5</testcontainers.version>
-    <commons-io.version>2.18.0</commons-io.version>
-    <localstack.version>1.20.5</localstack.version>
-    <sonar.exclusions>
-      **/src/main/java/org/folio/s3/client/S3ClientProperties.java
-    </sonar.exclusions>
+    <okhttp.version>5.3.2</okhttp.version>
+    <log4j.version>2.25.4</log4j.version>
+    <aws.sdk.version>2.42.34</aws.sdk.version>
+    <junit.version>6.0.3</junit.version>
+    <testcontainers.version>2.0.4</testcontainers.version>
+    <commons-io.version>2.21.0</commons-io.version>
   </properties>
 
   <dependencies>
@@ -93,8 +89,8 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>localstack</artifactId>
-      <version>${localstack.version}</version>
+      <artifactId>testcontainers-localstack</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -105,7 +101,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.16.1</version>
+        <version>2.21.0</version>
         <executions>
           <execution>
             <id>display-dependency</id>
@@ -123,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -144,7 +140,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -162,7 +158,7 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -176,7 +172,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -190,7 +186,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.4</version>
         <executions>
           <execution>
             <id>deploy</id>
@@ -205,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <compilerVersion>21</compilerVersion>
         </configuration>
@@ -214,7 +210,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.3.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -226,7 +222,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.5</version>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLS3CL-51

## Purpose
Upgrade all dependencies for Trillium.

This includes upgrades that fix security vulnerabilities:

* Upgrading aws sdk fixes netty security vulnerabilities:
  * Current: software.amazon.awssdk:s3-transfer-manager@2.40.17 › software.amazon.awssdk:s3@2.40.17 › software.amazon.awssdk:netty-nio-client@2.40.17 › io.netty:netty-codec-http@4.1.130.Final
  * https://www.cve.org/CVERecord?id=CVE-2026-33870 – netty-codec-http HTTP Request Smuggling
  * https://www.cve.org/CVERecord?id=CVE-2026-33871 – netty-codec-http2 Allocation of Resources Without Limits or Throttling
* Upgrading log4j fixes several security vulnerabilities:
  * https://www.cve.org/CVERecord?id=CVE-2025-68161
  * https://www.cve.org/CVERecord?id=CVE-2026-34477
  * https://www.cve.org/CVERecord?id=CVE-2026-34480
  * https://www.cve.org/CVERecord?id=CVE-2026-34479
  * https://www.cve.org/CVERecord?id=CVE-2026-34478

## Approach
Bump version in pom.xml

## Learning
Before the first release for a flower release bump all dependencies.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - n/a Were any API paths or methods changed, added or removed?
   - n/a Were there any schema changes?
   - n/a Did any of the interface versions change?
   - n/a Were permissions changed, added, or removed?
   - n/a Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.